### PR TITLE
Make rootless Docker publish workflow manual

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -1,29 +1,16 @@
 name: Docker publish rootless
 
 on:
-  schedule:
-    - cron: '00 0 * * *'
-  push:
-    branches: [ "main" ]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'Dockerfile.rootless'
-      - '.dockerignore'
-      - '.github/workflows/docker-publish-rootless.yaml'
-    ignore:
-      - 'docs/**'
-    tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ "main" ]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - 'Dockerfile.rootless'
-      - '.dockerignore'
-      - '.github/workflows/docker-publish-rootless.yaml'
-    ignore:
-      - 'docs/**'
+  workflow_dispatch:
+    inputs:
+      push_to_dockerhub:
+        description: 'Push the image to Docker Hub in addition to GHCR.'
+        type: boolean
+        default: true
+      custom_tag:
+        description: 'Optional additional tag to publish (e.g. v1.2.3).'
+        required: false
+        default: ''
 
 permissions:
   contents: read        # Access to repository contents
@@ -43,7 +30,10 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-      
+    env:
+      PUSH_TO_DOCKERHUB: ${{ fromJson(toJson(inputs.push_to_dockerhub)) ? 'true' : 'false' }}
+      CUSTOM_TAG: ${{ inputs.custom_tag }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -64,26 +54,33 @@ jobs:
 
       - name: Prepare
         run: |
+          set -euo pipefail
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
           branch=${{ github.event.pull_request.number || github.ref_name }}
           echo "BRANCH=${branch//\//-}" >> $GITHUB_ENV
-          echo "DOCKERNAMES=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}" >> $GITHUB_ENV
-          if [[ "${{ github.event_name }}" != "schedule" ]] || [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "DOCKERNAMES=${{ env.GHCR_REPO }}" >> $GITHUB_ENV
+          dockernames="${{ env.GHCR_REPO }}"
+          if [ "${{ env.PUSH_TO_DOCKERHUB }}" = "true" ]; then
+            dockernames="${dockernames},${{ env.DOCKERHUB_REPO }}"
           fi
+          echo "DOCKERNAMES=$dockernames" >> $GITHUB_ENV
+          version='${{ github.ref_name }}'
+          if [ -n "${{ env.CUSTOM_TAG }}" ]; then
+            version='${{ env.CUSTOM_TAG }}'
+          fi
+          echo "VERSION_ARG=$version" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            name=${{ env.DOCKERHUB_REPO }},enable=${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') }}
+            name=${{ env.DOCKERHUB_REPO }},enable=${{ env.PUSH_TO_DOCKERHUB == 'true' }}
             name=${{ env.GHCR_REPO }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/'))
+        if: env.PUSH_TO_DOCKERHUB == 'true'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -118,7 +115,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/sysadminsmedia/devcache:${{ env.PLATFORM_PAIR }}-${{ env.BRANCH }}-rootless
           cache-to: type=registry,ref=ghcr.io/sysadminsmedia/devcache:${{ env.PLATFORM_PAIR }}-${{ env.BRANCH }}-rootless,mode=max,ignore-error=true
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ env.VERSION_ARG }}
             COMMIT=${{ github.sha }}
           provenance: true
           sbom: true
@@ -148,6 +145,9 @@ jobs:
       attestations: write
     needs:
       - build
+    env:
+      PUSH_TO_DOCKERHUB: ${{ fromJson(toJson(inputs.push_to_dockerhub)) ? 'true' : 'false' }}
+      CUSTOM_TAG: ${{ inputs.custom_tag }}
 
     steps:
       - name: Download digests
@@ -159,7 +159,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/'))
+        if: env.PUSH_TO_DOCKERHUB == 'true'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -182,7 +182,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            name=${{ env.DOCKERHUB_REPO }},enable=${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') }}
+            name=${{ env.DOCKERHUB_REPO }},enable=${{ env.PUSH_TO_DOCKERHUB == 'true' }}
             name=${{ env.GHCR_REPO }}
           tags: |
             type=ref,event=branch
@@ -191,6 +191,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=schedule,pattern=nightly
+            type=raw,value=${{ env.CUSTOM_TAG }},enable=${{ env.CUSTOM_TAG != '' }}
           flavor: |
             suffix=-rootless,onlatest=true
 
@@ -204,7 +205,7 @@ jobs:
       - name: Create manifest list and push Dockerhub
         id: push-dockerhub
         working-directory: /tmp/digests
-        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/'))
+        if: env.PUSH_TO_DOCKERHUB == 'true'
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)


### PR DESCRIPTION
## Summary
- switch the rootless Docker publish workflow to run only via manual dispatch
- add inputs to control Docker Hub publishing and optional custom tags for manual releases
- ensure Docker Hub interactions and tagging logic honour the manual inputs

## Testing
- task swag --force *(fails: command not found in container)*
- task typescript-types --force *(fails: command not found in container)*
- task go:lint *(fails: command not found in container)*
- task ui:fix *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e24f7c4c588324858c8db1387145ef