### PR TITLE
Fix ternary syntax in rootless publish workflow

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -31,7 +31,7 @@ jobs:
       id-token: write
       attestations: write
     env:
-      PUSH_TO_DOCKERHUB: ${{ fromJson(toJson(inputs.push_to_dockerhub)) ? 'true' : 'false' }}
+      PUSH_TO_DOCKERHUB: ${{ inputs.push_to_dockerhub && 'true' || 'false' }}
       CUSTOM_TAG: ${{ inputs.custom_tag }}
 
     strategy:
@@ -146,7 +146,7 @@ jobs:
     needs:
       - build
     env:
-      PUSH_TO_DOCKERHUB: ${{ fromJson(toJson(inputs.push_to_dockerhub)) ? 'true' : 'false' }}
+      PUSH_TO_DOCKERHUB: ${{ inputs.push_to_dockerhub && 'true' || 'false' }}
       CUSTOM_TAG: ${{ inputs.custom_tag }}
 
     steps:


### PR DESCRIPTION
## Summary
- replace the invalid ternary-style GitHub expression used for PUSH_TO_DOCKERHUB
- ensure the workflow stores the boolean input as a string using logical operators so YAML parses correctly

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2537cf9348324a1254046544b5b3f