### PR TITLE
Ensure GHCR ref is lowercase in rootless Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   DOCKERHUB_REPO: sysadminsmedia/homebox
-  GHCR_REPO: ghcr.io/${{ github.repository }}
+  GHCR_REPO: ghcr.io/${{ github.repository | lower }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- ensure the GHCR repository reference used by the rootless Docker publish workflow is lowercased to satisfy registry naming rules

## Testing
- task swag --force
- task typescript-types --force
- task go:lint
- task ui:fix

------
https://chatgpt.com/codex/tasks/task_e_68e256137a8483248815fba4624c36ba