### PR TITLE
Lowercase GHCR repository in rootless workflow

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   DOCKERHUB_REPO: sysadminsmedia/homebox
-  GHCR_REPO: ${{ format('ghcr.io/{0}', toLower(github.repository)) }}
+  GHCR_REPO: ${{ format('ghcr.io/{0}', lower(github.repository)) }}
 
 jobs:
   build:

--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -20,7 +20,6 @@ permissions:
 
 env:
   DOCKERHUB_REPO: sysadminsmedia/homebox
-  GHCR_REPO: ${{ format('ghcr.io/{0}', lower(github.repository)) }}
 
 jobs:
   build:
@@ -51,6 +50,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set lowercase GHCR repository
+        run: echo "GHCR_REPO=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Prepare
         run: |

--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   DOCKERHUB_REPO: sysadminsmedia/homebox
-  GHCR_REPO: ghcr.io/${{ github.repository | lower }}
+  GHCR_REPO: ${{ format('ghcr.io/{0}', toLower(github.repository)) }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- ensure the GHCR repository definition lowercases `github.repository` without relying on the unsupported pipeline syntax

## Testing
- task swag --force *(fails: command not found)*
- task typescript-types --force *(fails: command not found)*
- task go:lint *(fails: command not found)*
- task ui:fix *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e25b357de88324938717d7e2b4c534