### PR TITLE
Fix GHCR repo metadata step in rootless docker workflow

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -179,6 +179,9 @@ jobs:
           driver-opts: |
             image=ghcr.io/amitie10g/buildkit:master
 
+      - name: Set lowercase GHCR repository
+        run: echo "GHCR_REPO=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## Summary
- ensure the rootless merge job exports the lowercase GHCR repository before invoking the metadata action so image tags are generated

## Testing
- task swag --force *(fails: `task` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e295ac52e883248fc3ff8149d9a62c